### PR TITLE
Test infrastructure + CI, and Windows empty-cert guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  analyze-and-test:
+    name: Analyze & Dart unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: dart format --output=none --set-exit-if-changed .
+      - run: flutter analyze
+      - run: flutter test
+
+  build-windows:
+    name: Build Windows (native compile)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Resolve dependencies
+        working-directory: example
+        run: flutter pub get
+      - name: Build Windows example
+        working-directory: example
+        run: flutter build windows --debug
+
+  # NOTE: Native gtest execution is intentionally NOT run in CI yet. The
+  # canonical runner (flutter_plugin_tools native-test) targets the
+  # flutter/packages monorepo layout and hangs on this single-package repo.
+  # The gtest target in windows/CMakeLists.txt is kept for local runs and is
+  # ready to wire into CI once a monorepo layout or a direct cmake/ctest
+  # harness is adopted. Until then, build-windows below validates that the
+  # native C++ compiles. Tracked as a follow-up in #12.
+
+  build-macos:
+    name: Build macOS (native compile)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Resolve dependencies
+        working-directory: example
+        run: flutter pub get
+      - name: Build macOS example
+        working-directory: example
+        run: flutter build macos --debug

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -30,6 +30,24 @@ void main() {
       certificateBase64: certificationBase64Str,
       addType: X509AddType.addNew,
     );
+    // Adding to ROOT without elevation fails; the exact code is
+    // environment-dependent (e.g. accessDenied), so only assert failure here.
     expect(rst, isA<X509Failure>());
+  });
+
+  // Deterministic across platforms and privilege levels: an empty certificate
+  // string decodes to empty bytes, passes the Dart base64 step, and must be
+  // rejected as invalidFormat by the native layer (regression for #7 on the
+  // native add path). Requires no admin rights.
+  testWidgets('empty certificate is rejected as invalidFormat',
+      (WidgetTester tester) async {
+    final X509CertStore plugin = X509CertStore();
+    final rst = await plugin.addCertificate(
+      storeName: X509StoreName.my,
+      certificateBase64: '',
+      addType: X509AddType.addNew,
+    );
+    expect(rst, isA<X509Failure>());
+    expect((rst as X509Failure).code, X509ErrorCode.invalidFormat);
   });
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -330,7 +330,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -24,3 +24,41 @@ set(x509_cert_store_bundled_libraries
   ""
   PARENT_SCOPE
 )
+
+# === Tests ===
+# These unit tests can be run from a terminal after building, or from Visual
+# Studio's Test Explorer via CTest integration. They are only configured when
+# the Flutter tooling requests them (e.g. flutter_plugin_tools native-test),
+# which defines include_${PROJECT_NAME}_tests.
+if (${include_${PROJECT_NAME}_tests})
+set(TEST_RUNNER "${PROJECT_NAME}_test")
+enable_testing()
+
+# Load GoogleTest using FetchContent.
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+)
+# Prevent overriding the parent project's compiler/linker settings.
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# The plugin's exported API is not useful for unit testing, so build the plugin
+# sources directly into the test binary rather than linking the shared library.
+add_executable(${TEST_RUNNER}
+  "test/x509_cert_store_plugin_test.cpp"
+  ${PLUGIN_SOURCES}
+)
+apply_standard_settings(${TEST_RUNNER})
+target_include_directories(${TEST_RUNNER} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(${TEST_RUNNER} PRIVATE flutter_wrapper_plugin)
+target_link_libraries(${TEST_RUNNER} PRIVATE Crypt32.lib)
+target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
+target_compile_definitions(${TEST_RUNNER} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Enable automatic test discovery.
+include(GoogleTest)
+gtest_discover_tests(${TEST_RUNNER})
+endif()

--- a/windows/test/x509_cert_store_plugin_test.cpp
+++ b/windows/test/x509_cert_store_plugin_test.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "x509_cert_store_plugin.h"
 
@@ -22,21 +23,65 @@ using flutter::MethodResultFunctions;
 
 }  // namespace
 
-TEST(X509CertStorePlugin, GetPlatformVersion) {
+// An unknown method name must be reported as not-implemented, not silently
+// swallowed. Exercises the plugin's method dispatch without touching the
+// certificate store.
+TEST(X509CertStorePlugin, UnknownMethodReturnsNotImplemented) {
   X509CertStorePlugin plugin;
-  // Save the reply value from the success callback.
-  std::string result_string;
-  plugin.HandleMethodCall(
-      MethodCall("getPlatformVersion", std::make_unique<EncodableValue>()),
-      std::make_unique<MethodResultFunctions<>>(
-          [&result_string](const EncodableValue* result) {
-            result_string = std::get<std::string>(*result);
-          },
-          nullptr, nullptr));
 
-  // Since the exact string varies by host, just ensure that it's a string
-  // with the expected format.
-  EXPECT_TRUE(result_string.rfind("Windows ", 0) == 0);
+  bool not_implemented = false;
+  plugin.HandleMethodCall(
+      MethodCall("thisMethodDoesNotExist", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr, nullptr,
+          [&not_implemented]() { not_implemented = true; }));
+
+  EXPECT_TRUE(not_implemented);
+}
+
+// Regression: an empty certificate (empty base64 on the Dart side decodes to
+// an empty byte vector) must be rejected as invalidFormat, not dereferenced.
+// The emptiness guard returns before opening a system store, so this test is
+// hermetic - it never touches the real certificate store.
+TEST(X509CertStorePlugin, AddCertificateRejectsEmptyData) {
+  X509CertStorePlugin plugin;
+
+  EncodableMap args;
+  args[EncodableValue("storeName")] = EncodableValue("MY");
+  args[EncodableValue("certificate")] = EncodableValue(std::vector<uint8_t>{});
+  args[EncodableValue("addType")] = EncodableValue(1);
+
+  std::string error_code;
+  bool got_success = false;
+  plugin.HandleMethodCall(
+      MethodCall("addCertificate", std::make_unique<EncodableValue>(args)),
+      std::make_unique<MethodResultFunctions<>>(
+          [&got_success](const EncodableValue*) { got_success = true; },
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_FALSE(got_success);
+  EXPECT_EQ(error_code, "invalidFormat");
+}
+
+// addCertificate with non-map arguments is rejected as "unknown" without
+// touching the certificate store.
+TEST(X509CertStorePlugin, AddCertificateRejectsMissingArguments) {
+  X509CertStorePlugin plugin;
+
+  std::string error_code;
+  bool got_success = false;
+  plugin.HandleMethodCall(
+      MethodCall("addCertificate", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          [&got_success](const EncodableValue*) { got_success = true; },
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_FALSE(got_success);
+  EXPECT_EQ(error_code, "unknown");
 }
 
 }  // namespace test

--- a/windows/x509_cert_store_plugin.cpp
+++ b/windows/x509_cert_store_plugin.cpp
@@ -114,6 +114,16 @@ bool AddCertificateToStore(
   category = "unknown";
   nativeCode = 0;
 
+  // Guard against empty input before any indexing (certificateData[0] below)
+  // or store handle allocation. An empty base64 string on the Dart side
+  // decodes to an empty vector, which would otherwise be an out-of-bounds
+  // read. macOS surfaces this as invalidFormat; match that here.
+  if (certificateData.empty()) {
+    category = "invalidFormat";
+    errorMessage = "Certificate data is empty";
+    return false;
+  }
+
   HCERTSTORE hStore = CertOpenSystemStoreA(NULL, storeName.c_str());
   if (!hStore) {
     nativeCode = GetLastError();


### PR DESCRIPTION
Adds test infrastructure and CI (#12) and fixes the Windows empty-certificate out-of-bounds read (#7). The two are bundled because #7's native regression test only builds under the CMake test target added by #12.

## Commits

- **fix(windows): reject empty certificate input instead of OOB read** (Closes #7)
  Empty base64 -> empty byte vector -> `certificateData[0]` OOB read on Windows. Guarded before opening a store handle; now surfaces `invalidFormat`, matching macOS. Adds a deterministic integration test (empty cert -> invalidFormat, no admin needed).

- **test(windows): wire native gtest target + add CI** (Closes #12)
  - `windows/CMakeLists.txt`: standard Flutter plugin gtest target (guarded by `include_x509_cert_store_tests`) so `windows/test/*.cpp` actually compiles/runs via CTest locally.
  - Replaced the stale `GetPlatformVersion` gtest (plugin returns `NotImplemented`) with hermetic dispatch / empty-data / missing-argument tests.
  - GitHub Actions CI: `flutter analyze` + `dart format` + `flutter test` (Dart), and `flutter build windows`/`macos` for native compile validation.

## Verified locally

- `flutter analyze` (root + example): clean
- `dart format --set-exit-if-changed .`: clean
- `flutter test` (Dart unit tests): 7 passing
- `windows/` sources: pure ASCII

## Not yet verified (honest note)

- **Native gtest execution.** The canonical runner (`flutter_plugin_tools native-test`) targets the flutter/packages monorepo layout and hangs on this single-package repo, so it is deliberately excluded from CI. The gtest target is kept for local runs and is ready to wire in once a monorepo layout or a direct cmake/ctest harness is adopted. CI validates that the native C++ compiles via `flutter build windows`.
- **CI YAML** has not run yet; this PR is its first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)