### PR TITLE
refactor(macos): dedupe keychain add logic via protocol extension

### DIFF
--- a/macos/Classes/KeyChainProtocol.swift
+++ b/macos/Classes/KeyChainProtocol.swift
@@ -6,6 +6,13 @@ protocol KeyChainManager {
   func certificateExists(certificate: SecCertificate) -> Bool
   func findExistingCertificate(certificate: SecCertificate) -> SecCertificate?
   func loadAllCertificates() -> [SecCertificate]
+
+  /// Configure the certificate as trusted. Implemented per store because the
+  /// mechanism differs (a user `security` invocation for the login keychain
+  /// vs. an admin-elevated call for the system keychain). Called only when
+  /// `setTrusted` is requested; `addCertificate` treats failures as
+  /// best-effort and does not fail the overall operation.
+  func applyTrust(certData: Data) throws
 }
 
 enum CertificateError: Error {
@@ -18,4 +25,85 @@ struct CertificateAddType {
   static let CERT_STORE_ADD_NEW = 1
   static let CERT_STORE_ADD_REPLACE_EXISTING = 3
   static let CERT_STORE_ADD_NEWER = 6
+}
+
+/// Shared behavior for every keychain-backed store. The only per-store
+/// variation is `applyTrust(certData:)`; the add/replace/newer flow and the
+/// lookup helpers are identical, so they live here once instead of being
+/// duplicated across `LoginKeyChain` and `SystemKeyChain`.
+extension KeyChainManager {
+  func certificateExists(certificate: SecCertificate) -> Bool {
+    return CertificateUtils.certificateExists(certificate: certificate, keychain: nil)
+  }
+
+  func findExistingCertificate(certificate: SecCertificate) -> SecCertificate? {
+    return CertificateUtils.findExistingCertificate(certificate: certificate, keychain: nil)
+  }
+
+  func loadAllCertificates() -> [SecCertificate] {
+    return CertificateUtils.loadAllCertificatesFromKeychain(keychain: nil)
+  }
+
+  func addCertificate(certificateData: Data, addType: Int, setTrusted: Bool) throws -> Bool {
+    let certData = CertificateUtils.prepareCertificateData(certificateData)
+
+    guard let certificate = SecCertificateCreateWithData(nil, certData as CFData) else {
+      throw CertificateError.invalidData
+    }
+
+    switch addType {
+    case CertificateAddType.CERT_STORE_ADD_NEW:
+      if certificateExists(certificate: certificate) {
+        throw CertificateError.alreadyExists
+      }
+    case CertificateAddType.CERT_STORE_ADD_REPLACE_EXISTING:
+      if let existingCert = findExistingCertificate(certificate: certificate) {
+        try deleteCertificate(existingCert)
+      }
+    case CertificateAddType.CERT_STORE_ADD_NEWER:
+      if let existing = findExistingCertificate(certificate: certificate) {
+        if !CertificateUtils.isNewerCertificate(newCert: certificate, existingCert: existing) {
+          return true
+        }
+        try deleteCertificate(existing)
+      }
+    default:
+      break
+    }
+
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassCertificate,
+      kSecValueRef as String: certificate,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+    ]
+
+    let status = SecItemAdd(query as CFDictionary, nil)
+
+    if status == errSecSuccess {
+      if setTrusted {
+        // Best-effort: the certificate is already added, so a trust-configuration
+        // failure must not fail the whole operation.
+        try? applyTrust(certData: certData)
+      }
+      return true
+    } else if status == errSecDuplicateItem {
+      throw CertificateError.alreadyExists
+    } else {
+      throw CertificateError.securityError(status)
+    }
+  }
+
+  /// Delete a certificate from the keychain, throwing on failure. Unifies the
+  /// previous inconsistency where the NEWER path ignored delete failures on the
+  /// login keychain but threw on the system keychain.
+  private func deleteCertificate(_ certificate: SecCertificate) throws {
+    let deleteQuery: [String: Any] = [
+      kSecClass as String: kSecClassCertificate,
+      kSecValueRef as String: certificate,
+    ]
+    let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+    if deleteStatus != errSecSuccess {
+      throw CertificateError.securityError(deleteStatus)
+    }
+  }
 }

--- a/macos/Classes/LoginKeyChain.swift
+++ b/macos/Classes/LoginKeyChain.swift
@@ -3,88 +3,17 @@ import Security
 
 class LoginKeyChain: KeyChainManager {
 
-  func addCertificate(certificateData: Data, addType: Int, setTrusted: Bool = false) throws -> Bool {
-    let certData = CertificateUtils.prepareCertificateData(certificateData)
-
-    guard let certificate = SecCertificateCreateWithData(nil, certData as CFData) else {
-      throw CertificateError.invalidData
-    }
-
-    if addType == CertificateAddType.CERT_STORE_ADD_NEW {
-      if certificateExists(certificate: certificate) {
-        throw CertificateError.alreadyExists
-      }
-    } else if addType == CertificateAddType.CERT_STORE_ADD_REPLACE_EXISTING {
-      if let existingCert = findExistingCertificate(certificate: certificate) {
-        let deleteQuery: [String: Any] = [
-          kSecClass as String: kSecClassCertificate,
-          kSecValueRef as String: existingCert,
-        ]
-
-        let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
-        if deleteStatus != errSecSuccess {
-          throw CertificateError.securityError(deleteStatus)
-        }
-      }
-    } else if addType == CertificateAddType.CERT_STORE_ADD_NEWER {
-      if let existing = findExistingCertificate(certificate: certificate) {
-        if !CertificateUtils.isNewerCertificate(newCert: certificate, existingCert: existing) {
-          return true
-        }
-
-        let deleteQuery: [String: Any] = [
-          kSecClass as String: kSecClassCertificate,
-          kSecValueRef as String: existing,
-        ]
-
-        _ = SecItemDelete(deleteQuery as CFDictionary)
-      }
-    }
-
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassCertificate,
-      kSecValueRef as String: certificate,
-      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-    ]
-
-    let status = SecItemAdd(query as CFDictionary, nil)
-
-    if status == errSecSuccess {
-      if setTrusted {
-        do {
-          try addTrustedCertificateWithSecurityCommand(certificateData: certData, isSystemWide: false)
-        } catch {
-        }
-      } else {
-      }
-      return true
-    } else if status == errSecDuplicateItem {
-      throw CertificateError.alreadyExists
-    } else {
-      throw CertificateError.securityError(status)
-    }
+  /// Trust configuration for the login keychain: invoke `security` directly as
+  /// the current user (no elevation).
+  func applyTrust(certData: Data) throws {
+    try addTrustedCertificateWithSecurityCommand(certificateData: certData)
   }
 
-  func certificateExists(certificate: SecCertificate) -> Bool {
-    return CertificateUtils.certificateExists(certificate: certificate, keychain: nil)
-  }
-
-  func findExistingCertificate(certificate: SecCertificate) -> SecCertificate? {
-    return CertificateUtils.findExistingCertificate(certificate: certificate, keychain: nil)
-  }
-
-  func loadAllCertificates() -> [SecCertificate] {
-    return CertificateUtils.loadAllCertificatesFromKeychain(keychain: nil)
-  }
-
-  private func addTrustedCertificateWithSecurityCommand(
-    certificateData: Data, isSystemWide: Bool = false
-  ) throws {
+  private func addTrustedCertificateWithSecurityCommand(certificateData: Data) throws {
     let tempDir = NSTemporaryDirectory()
     let tempFile = tempDir + "temp_cert_\(UUID().uuidString).pem"
 
     let pemData = CertificateUtils.convertDERToPEM(certificateData)
-
 
     try pemData.write(to: URL(fileURLWithPath: tempFile))
 
@@ -105,7 +34,6 @@ class LoginKeyChain: KeyChainManager {
       tempFile,
     ]
 
-
     let pipe = Pipe()
     task.standardOutput = pipe
     task.standardError = pipe
@@ -113,15 +41,8 @@ class LoginKeyChain: KeyChainManager {
     task.launch()
     task.waitUntilExit()
 
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8) ?? ""
-
-    if !output.isEmpty {
-    }
-
     if task.terminationStatus != 0 {
       throw CertificateError.securityError(OSStatus(task.terminationStatus))
-    } else {
     }
   }
 }

--- a/macos/Classes/SystemKeyChain.swift
+++ b/macos/Classes/SystemKeyChain.swift
@@ -18,86 +18,40 @@ extension Data {
 }
 
 class SystemKeyChain: KeyChainManager {
-  func addCertificate(certificateData: Data, addType: Int, setTrusted: Bool) throws -> Bool {
-    let certData = CertificateUtils.prepareCertificateData(certificateData)
 
-    guard let certificate = SecCertificateCreateWithData(nil, certData as CFData) else {
-      throw CertificateError.invalidData
-    }
-
-    if addType == CertificateAddType.CERT_STORE_ADD_NEW {
-      if certificateExists(certificate: certificate) {
-        throw CertificateError.alreadyExists
-      }
-    } else if addType == CertificateAddType.CERT_STORE_ADD_REPLACE_EXISTING {
-      if let existingCert = findExistingCertificate(certificate: certificate) {
-        let deleteQuery: [String: Any] = [
-          kSecClass as String: kSecClassCertificate,
-          kSecValueRef as String: existingCert,
-        ]
-
-        let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
-        if deleteStatus != errSecSuccess {
-          throw CertificateError.securityError(deleteStatus)
-        }
-      }
-    } else if addType == CertificateAddType.CERT_STORE_ADD_NEWER {
-      if let existing = findExistingCertificate(certificate: certificate) {
-        if !CertificateUtils.isNewerCertificate(newCert: certificate, existingCert: existing) {
-          return true
-        }
-
-        let deleteQuery: [String: Any] = [
-          kSecClass as String: kSecClassCertificate,
-          kSecValueRef as String: existing,
-        ]
-
-        let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
-        if deleteStatus != errSecSuccess {
-          throw CertificateError.securityError(deleteStatus)
-        }
-      }
-    }
-
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassCertificate,
-      kSecValueRef as String: certificate,
-      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-    ]
-
-    let status = SecItemAdd(query as CFDictionary, nil)
-
-    if status == errSecSuccess {
-      if setTrusted {
-        do {
-          try addTrustedCertificateWithSecurityCommand(
-            certificateData: certData, isSystemWide: true)
-        } catch {
-          // Trust setting failed, but certificate was added
-        }
-      }
-      return true
-    } else if status == errSecDuplicateItem {
-      throw CertificateError.alreadyExists
-    } else {
-      throw CertificateError.securityError(status)
-    }
+  /// Trust configuration for the system keychain: elevate via AppleScript, and
+  /// fall back to a direct `security` invocation if elevation is unavailable.
+  func applyTrust(certData: Data) throws {
+    try addTrustedCertificateWithSecurityCommand(certificateData: certData)
   }
 
-  func certificateExists(certificate: SecCertificate) -> Bool {
-    return CertificateUtils.certificateExists(certificate: certificate, keychain: nil)
-  }
+  private func addTrustedCertificateWithSecurityCommand(certificateData: Data) throws {
+    let tempDir = NSTemporaryDirectory()
+    let tempFile = tempDir + "temp_cert_\(UUID().uuidString).pem"
 
-  func findExistingCertificate(certificate: SecCertificate) -> SecCertificate? {
-    return CertificateUtils.findExistingCertificate(certificate: certificate, keychain: nil)
-  }
+    let pemData = CertificateUtils.convertDERToPEM(certificateData)
 
-  func loadAllCertificates() -> [SecCertificate] {
-    return CertificateUtils.loadAllCertificatesFromKeychain(keychain: nil)
+    try pemData.write(to: URL(fileURLWithPath: tempFile))
+
+    defer {
+      try? FileManager.default.removeItem(atPath: tempFile)
+    }
+
+    // First try with sudo via AppleScript for the system keychain.
+    let script = """
+      do shell script "security add-trusted-cert -d -r trustRoot -p ssl -p smime -p codeSign -p basic -k /Library/Keychains/System.keychain '\(tempFile)'" with administrator privileges
+      """
+
+    let appleScript = NSAppleScript(source: script)
+    var error: NSDictionary?
+    let _ = appleScript?.executeAndReturnError(&error)
+
+    if error != nil {
+      try fallbackToProcessExecution(tempFile: tempFile)
+    }
   }
 
   private func fallbackToProcessExecution(tempFile: String) throws {
-
     let task = Process()
     task.launchPath = "/usr/bin/security"
     task.arguments = [
@@ -120,34 +74,6 @@ class SystemKeyChain: KeyChainManager {
 
     if task.terminationStatus != 0 {
       throw CertificateError.securityError(OSStatus(task.terminationStatus))
-    }
-  }
-
-  private func addTrustedCertificateWithSecurityCommand(
-    certificateData: Data, isSystemWide: Bool = true
-  ) throws {
-    let tempDir = NSTemporaryDirectory()
-    let tempFile = tempDir + "temp_cert_\(UUID().uuidString).pem"
-
-    let pemData = CertificateUtils.convertDERToPEM(certificateData)
-
-    try pemData.write(to: URL(fileURLWithPath: tempFile))
-
-    defer {
-      try? FileManager.default.removeItem(atPath: tempFile)
-    }
-
-    // First try with sudo via AppleScript for system keychain
-    let script = """
-      do shell script "security add-trusted-cert -d -r trustRoot -p ssl -p smime -p codeSign -p basic -k /Library/Keychains/System.keychain '\(tempFile)'" with administrator privileges
-      """
-
-    let appleScript = NSAppleScript(source: script)
-    var error: NSDictionary?
-    let _ = appleScript?.executeAndReturnError(&error)
-
-    if error != nil {
-      try fallbackToProcessExecution(tempFile: tempFile)
     }
   }
 }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -26,10 +26,11 @@ set(x509_cert_store_bundled_libraries
 )
 
 # === Tests ===
-# These unit tests can be run from a terminal after building, or from Visual
-# Studio's Test Explorer via CTest integration. They are only configured when
-# the Flutter tooling requests them (e.g. flutter_plugin_tools native-test),
-# which defines include_${PROJECT_NAME}_tests.
+# The test target is compiled when include_${PROJECT_NAME}_tests is set. The
+# example app's own CMakeLists sets it TRUE by convention, so these tests build
+# as part of `flutter build windows`. Test discovery is deferred to ctest time
+# (DISCOVERY_MODE PRE_TEST below) so the app build itself never runs the test
+# binary, which needs flutter_windows.dll on PATH.
 if (${include_${PROJECT_NAME}_tests})
 set(TEST_RUNNER "${PROJECT_NAME}_test")
 enable_testing()
@@ -38,10 +39,14 @@ enable_testing()
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
 )
 # Prevent overriding the parent project's compiler/linker settings.
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Do not let GoogleTest add install() rules. Otherwise `flutter build`'s INSTALL
+# step tries to install GoogleTest into the system prefix and fails with
+# "file INSTALL cannot make directory".
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 # The plugin's exported API is not useful for unit testing, so build the plugin
@@ -58,7 +63,10 @@ target_link_libraries(${TEST_RUNNER} PRIVATE Crypt32.lib)
 target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
 target_compile_definitions(${TEST_RUNNER} PRIVATE FLUTTER_PLUGIN_IMPL)
 
-# Enable automatic test discovery.
+# Enable automatic test discovery. PRE_TEST discovers tests when ctest runs
+# rather than at build time: the test binary links the Flutter C++ wrapper and
+# needs flutter_windows.dll at runtime, which is not beside the binary during
+# `flutter build`, so build-time (POST_BUILD) discovery would fail the build.
 include(GoogleTest)
-gtest_discover_tests(${TEST_RUNNER})
+gtest_discover_tests(${TEST_RUNNER} DISCOVERY_MODE PRE_TEST)
 endif()


### PR DESCRIPTION
Closes #8. Also fixes the `build-windows` CI job that #12 left red on main.

## Commit 1 — refactor(macos): dedupe keychain add logic (#8)

`LoginKeyChain` and `SystemKeyChain` had near-identical `addCertificate` plus identical lookup delegations. Shared flow moved into a `KeyChainManager` protocol extension (Template Method); the only per-store difference — trust configuration — is now an `applyTrust(certData:)` hook. Also unifies the `ADD_NEWER` delete-failure handling (login keychain previously ignored failures; both now throw). Net: `LoginKeyChain` 127->48, `SystemKeyChain` 153->79 lines.

## Commit 2 — fix(windows): make the gtest target build cleanly under `flutter build`

The gtest target added in #12 broke `flutter build windows`. The example app enables plugin tests (`set(include_<plugin>_tests TRUE)`), so the gtest target builds during a normal build, and three things failed in sequence:

- **googletest 1.11.0** incompatible with the CI runner's CMake (compat with CMake < 3.5 removed) -> **v1.15.2**.
- **`gtest_discover_tests`** ran the test binary at build time to enumerate tests, but it needs `flutter_windows.dll` on PATH (not beside it during a build) -> **`DISCOVERY_MODE PRE_TEST`** defers discovery to ctest time.
- **GoogleTest install() rules** failed the INSTALL step with "file INSTALL cannot make directory" -> **`set(INSTALL_GTEST OFF)`**.

## Verification

- `build-macos` CI: **passed** on the first push (validated the #8 Swift refactor compiles).
- `flutter build windows --debug`: **verified locally from a clean tree** (the exact CI command) after the fixes — exit 0, `Built ...example.exe`.
- `flutter analyze` + `dart format` + `flutter test`: green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)