### PR TITLE
fix(macos): stop leaking CFError in isNewerCertificate

### DIFF
--- a/macos/Classes/CertificateUtils.swift
+++ b/macos/Classes/CertificateUtils.swift
@@ -30,16 +30,15 @@ class CertificateUtils {
   }
   
   static func isNewerCertificate(newCert: SecCertificate, existingCert: SecCertificate) -> Bool {
-    var error: Unmanaged<CFError>?
-
-    guard let newProps = SecCertificateCopyValues(newCert, nil, &error) as? [CFString: Any] else {
+    // Pass nil for the error out-parameter. The failure paths below never
+    // inspect the error, and requesting an Unmanaged<CFError> that we then fail
+    // to release would leak one CFError per failed lookup.
+    guard let newProps = SecCertificateCopyValues(newCert, nil, nil) as? [CFString: Any] else {
       return false
     }
 
-    error = nil
-
     guard
-      let existingProps = SecCertificateCopyValues(existingCert, nil, &error) as? [CFString: Any]
+      let existingProps = SecCertificateCopyValues(existingCert, nil, nil) as? [CFString: Any]
     else {
       return false
     }


### PR DESCRIPTION
Closes #10.

`SecCertificateCopyValues` in `isNewerCertificate` (`macos/Classes/CertificateUtils.swift`) was called with an `Unmanaged<CFError>` out-parameter that the failure `guard`s returned past without releasing — leaking one `CFError` per failed lookup (i.e. whenever a certificate's values can't be read).

## Fix

The error value was never inspected on any path, so pass `nil` for the out-parameter instead of requesting an `Unmanaged<CFError>` we then drop. This removes the leak by construction and is behavior-preserving (both failure paths still `return false`).

## Verification

- macOS Swift can't be built on the Windows dev host, so this is validated by the `build-macos` CI job (compile gate). Please let CI go green before merging.
- The other `SecCertificateCopyValues` / `Unmanaged` audit came up clean — this was the only such site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)