### PR TITLE
fix: #11 minor cleanups (defensive result handling + PEM guard)

### DIFF
--- a/lib/src/x509_cert_store_method_channel.dart
+++ b/lib/src/x509_cert_store_method_channel.dart
@@ -35,7 +35,7 @@ class MethodChannelX509CertStore extends X509CertStorePlatform {
     try {
       final certificateBytes = base64.decode(certificateBase64);
 
-      await methodChannel.invokeMethod<bool>(
+      final added = await methodChannel.invokeMethod<bool>(
         'addCertificate',
         {
           'storeName': storeName.getString(),
@@ -45,7 +45,18 @@ class MethodChannelX509CertStore extends X509CertStorePlatform {
         },
       );
 
-      return const X509Success();
+      if (added == true) {
+        return const X509Success();
+      }
+
+      // Native side signals failure by throwing a PlatformException; a
+      // non-true return without an exception is unexpected, so surface it as
+      // an unknown failure rather than reporting a false success.
+      return const X509Failure(
+        code: X509ErrorCode.unknown,
+        msg:
+            'Native addCertificate returned a non-true result without an error',
+      );
     } on PlatformException catch (error) {
       return _failureFromPlatformException(error);
     } on FormatException catch (error) {

--- a/test/x509_cert_store_method_channel_test.dart
+++ b/test/x509_cert_store_method_channel_test.dart
@@ -28,6 +28,21 @@ void main() {
       expect(result, isA<X509Success>());
     });
 
+    test('Native returns false without throwing → X509Failure(unknown)',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async => false);
+
+      final result = await certStore.addCertificate(
+        storeName: X509StoreName.my,
+        certificateBase64: dummyCertBase64,
+        addType: X509AddType.addNew,
+      );
+
+      expect(result, isA<X509Failure>());
+      expect((result as X509Failure).code, X509ErrorCode.unknown);
+    });
+
     test(
         'PlatformException(code: "unknown", details: {nativeCode: N}) '
         '→ X509Failure(code: unknown, nativeCode: N)', () async {

--- a/windows/x509_cert_store_plugin.cpp
+++ b/windows/x509_cert_store_plugin.cpp
@@ -73,6 +73,12 @@ std::vector<BYTE> ConvertPemToDer(const std::vector<BYTE>& inputData) {
   if (beginPos != std::string::npos && endPos != std::string::npos) {
     beginPos += strlen("-----BEGIN CERTIFICATE-----");
 
+    // Guard against a malformed PEM where the END marker precedes BEGIN:
+    // endPos - beginPos would underflow (size_t) and throw from substr.
+    if (endPos <= beginPos) {
+      return {};
+    }
+
     std::string base64Cert = pemCert.substr(beginPos, endPos - beginPos);
     base64Cert.erase(std::remove(base64Cert.begin(), base64Cert.end(), '\n'), base64Cert.end());
     base64Cert.erase(std::remove(base64Cert.begin(), base64Cert.end(), '\r'), base64Cert.end());


### PR DESCRIPTION
Closes #11.

The #11 checklist had four items. Two were already resolved by #8 (the KeyChain dedup); the remaining two are addressed here.

## Done here

- **fix(dart): non-true native result -> failure, not false success.** `MethodChannelX509CertStore` ignored the bool from `invokeMethod` and always returned `X509Success`. A non-true return without a thrown `PlatformException` is now surfaced as `X509Failure(unknown)`. **Developed test-first** (RED: a mock returning `false` asserted `X509Failure` and failed against the old code; GREEN after the fix).
- **fix(windows): guard PEM parse against END-before-BEGIN underflow.** In `ConvertPemToDer`, a malformed PEM whose END marker precedes BEGIN made `endPos - beginPos` underflow (`size_t`) and throw from `substr`. Now guarded explicitly, returning empty -> `invalidFormat`.

## Already handled by #8

- **Dead code (empty if/else logging blocks in LoginKeyChain):** removed when `LoginKeyChain` was rewritten in #8.
- **Silent `setTrusted` failure:** now documented in #8 as intentional best-effort (`try?` with an explanatory comment) — trust configuration failing must not fail a successful add.

## Verification

- `flutter test`: **8 pass** (the new false-return test included); `flutter analyze` + `dart format`: clean locally.
- The Windows PEM guard compiles via the `build-windows` CI job (no hermetic unit test — that path runs after the store is opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)