### PR TITLE
refactor: centralize stringly-typed error-category keys (#9)

### DIFF
--- a/lib/src/x509_cert_store_method_channel.dart
+++ b/lib/src/x509_cert_store_method_channel.dart
@@ -94,16 +94,30 @@ class MethodChannelX509CertStore extends X509CertStorePlatform {
 
   X509ErrorCode _parseCategory(String key) {
     switch (key) {
-      case 'canceled':
+      case _CategoryKeys.canceled:
         return X509ErrorCode.canceled;
-      case 'alreadyExist':
+      case _CategoryKeys.alreadyExist:
         return X509ErrorCode.alreadyExist;
-      case 'accessDenied':
+      case _CategoryKeys.accessDenied:
         return X509ErrorCode.accessDenied;
-      case 'invalidFormat':
+      case _CategoryKeys.invalidFormat:
         return X509ErrorCode.invalidFormat;
+      case _CategoryKeys.unknown:
+        return X509ErrorCode.unknown;
       default:
         return X509ErrorCode.unknown;
     }
   }
+}
+
+/// The X509ErrorCode category keys received over the method channel. These
+/// strings are the wire contract shared with the native layers; keep them in
+/// sync with windows/x509_cert_store_categories.h and
+/// macos/Classes/CategoryKeys.swift.
+abstract final class _CategoryKeys {
+  static const canceled = 'canceled';
+  static const alreadyExist = 'alreadyExist';
+  static const accessDenied = 'accessDenied';
+  static const invalidFormat = 'invalidFormat';
+  static const unknown = 'unknown';
 }

--- a/macos/Classes/CategoryKeys.swift
+++ b/macos/Classes/CategoryKeys.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// The X509ErrorCode category keys sent over the method channel. These strings
+/// are the wire contract shared with the Dart and Windows layers; keep them in
+/// sync with lib/src/x509_cert_store_method_channel.dart and
+/// windows/x509_cert_store_categories.h.
+enum X509Category {
+  static let canceled = "canceled"
+  static let alreadyExist = "alreadyExist"
+  static let accessDenied = "accessDenied"
+  static let invalidFormat = "invalidFormat"
+  static let unknown = "unknown"
+}

--- a/macos/Classes/X509CertStorePlugin.swift
+++ b/macos/Classes/X509CertStorePlugin.swift
@@ -21,7 +21,7 @@ public class X509CertStorePlugin: NSObject, FlutterPlugin {
         let certificateData = args["certificate"] as? FlutterStandardTypedData,
         let addType = args["addType"] as? Int
       else {
-        result(Self.failure(category: "unknown", message: "Missing or invalid arguments"))
+        result(Self.failure(category: X509Category.unknown, message: "Missing or invalid arguments"))
         return
       }
 
@@ -39,29 +39,29 @@ public class X509CertStorePlugin: NSObject, FlutterPlugin {
           result(true)
         } else {
           // Usually unreachable — the underlying call throws on failure.
-          result(Self.failure(category: "unknown", message: "Failed to add certificate"))
+          result(Self.failure(category: X509Category.unknown, message: "Failed to add certificate"))
         }
       } catch CertificateError.invalidData {
         result(Self.failure(
-          category: "invalidFormat",
+          category: X509Category.invalidFormat,
           message: "Invalid certificate data"))
       } catch CertificateError.alreadyExists {
         // Pre-empted by certificateExists() or surfaced as
         // errSecDuplicateItem; either way the category is alreadyExist.
         result(Self.failure(
-          category: "alreadyExist",
+          category: X509Category.alreadyExist,
           message: "Certificate already exists"))
       } catch CertificateError.securityError(let code) {
         // Try to map the OSStatus to a known category; otherwise fall
         // back to "unknown" and preserve the raw value for diagnostics.
-        let category = Self.mapOSStatus(code) ?? "unknown"
+        let category = Self.mapOSStatus(code) ?? X509Category.unknown
         result(Self.failure(
           category: category,
           message: "Security framework error: \(code)",
           nativeCode: Int(code)))
       } catch {
         result(Self.failure(
-          category: "unknown",
+          category: X509Category.unknown,
           message: "An unexpected error occurred: \(error)"))
       }
 
@@ -88,13 +88,13 @@ public class X509CertStorePlugin: NSObject, FlutterPlugin {
   private static func mapOSStatus(_ status: OSStatus) -> String? {
     switch status {
     case errSecDuplicateItem:
-      return "alreadyExist"
+      return X509Category.alreadyExist
     case errSecUserCanceled:
-      return "canceled"
+      return X509Category.canceled
     case errSecAuthFailed:
-      return "accessDenied"
+      return X509Category.accessDenied
     case errSecDecode:
-      return "invalidFormat"
+      return X509Category.invalidFormat
     default:
       return nil
     }
@@ -112,7 +112,7 @@ public class X509CertStorePlugin: NSObject, FlutterPlugin {
     nativeCode: Int? = nil
   ) -> FlutterError {
     let codeValue: Any
-    if category == "unknown" {
+    if category == X509Category.unknown {
       codeValue = nativeCode ?? NSNull()
     } else {
       codeValue = NSNull()

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PLUGIN_NAME "x509_cert_store_plugin")
 list(APPEND PLUGIN_SOURCES
   "x509_cert_store_plugin.cpp"
   "x509_cert_store_plugin.h"
+  "x509_cert_store_categories.h"
 )
 add_library(${PLUGIN_NAME} SHARED
   "include/x509_cert_store/x509_cert_store_plugin_c_api.h"

--- a/windows/test/x509_cert_store_plugin_test.cpp
+++ b/windows/test/x509_cert_store_plugin_test.cpp
@@ -3,12 +3,14 @@
 #include <flutter/standard_method_codec.h>
 #include <gtest/gtest.h>
 #include <windows.h>
+#include <wincrypt.h>
 
 #include <memory>
 #include <string>
 #include <variant>
 #include <vector>
 
+#include "x509_cert_store_categories.h"
 #include "x509_cert_store_plugin.h"
 
 namespace x509_cert_store {
@@ -82,6 +84,37 @@ TEST(X509CertStorePlugin, AddCertificateRejectsMissingArguments) {
 
   EXPECT_FALSE(got_success);
   EXPECT_EQ(error_code, "unknown");
+}
+
+// The category keys are the wire contract shared with the Dart and Swift
+// layers. Assert against the literal strings (not the category:: constants) so
+// a typo in either a constant or the mapping is caught, rather than comparing a
+// value to itself.
+TEST(X509CertStoreCategories, MapsKnownWin32ErrorsToWireKeys) {
+  // CRYPT_E_EXISTS is an HRESULT; cast to DWORD to avoid a signed/unsigned
+  // conversion warning (treated as an error under /WX).
+  EXPECT_EQ(CategoryFromWinError(static_cast<DWORD>(CRYPT_E_EXISTS)),
+            "alreadyExist");
+  EXPECT_EQ(CategoryFromWinError(static_cast<DWORD>(ERROR_CANCELLED)),
+            "canceled");
+  EXPECT_EQ(CategoryFromWinError(static_cast<DWORD>(ERROR_ACCESS_DENIED)),
+            "accessDenied");
+}
+
+TEST(X509CertStoreCategories, UnmappedWin32ErrorCollapsesToUnknown) {
+  EXPECT_FALSE(
+      MapWinErrorToCategory(static_cast<DWORD>(ERROR_INVALID_HANDLE))
+          .has_value());
+  EXPECT_EQ(CategoryFromWinError(static_cast<DWORD>(ERROR_INVALID_HANDLE)),
+            "unknown");
+}
+
+TEST(X509CertStoreCategories, ConstantsMatchWireContract) {
+  EXPECT_EQ(std::string(category::kCanceled), "canceled");
+  EXPECT_EQ(std::string(category::kAlreadyExist), "alreadyExist");
+  EXPECT_EQ(std::string(category::kAccessDenied), "accessDenied");
+  EXPECT_EQ(std::string(category::kInvalidFormat), "invalidFormat");
+  EXPECT_EQ(std::string(category::kUnknown), "unknown");
 }
 
 }  // namespace test

--- a/windows/x509_cert_store_categories.h
+++ b/windows/x509_cert_store_categories.h
@@ -1,0 +1,32 @@
+#ifndef FLUTTER_PLUGIN_X509_CERT_STORE_CATEGORIES_H_
+#define FLUTTER_PLUGIN_X509_CERT_STORE_CATEGORIES_H_
+
+#include <windows.h>
+
+#include <optional>
+#include <string>
+
+namespace x509_cert_store {
+
+// The X509ErrorCode category keys sent over the method channel. These strings
+// are the wire contract shared with the Dart and Swift layers; keep them in
+// sync with lib/src/x509_cert_store_method_channel.dart and
+// macos/Classes/CategoryKeys.swift.
+namespace category {
+constexpr char kCanceled[] = "canceled";
+constexpr char kAlreadyExist[] = "alreadyExist";
+constexpr char kAccessDenied[] = "accessDenied";
+constexpr char kInvalidFormat[] = "invalidFormat";
+constexpr char kUnknown[] = "unknown";
+}  // namespace category
+
+// Map a Win32 / wincrypt errcode to a category key, or std::nullopt if the code
+// is unmapped.
+std::optional<std::string> MapWinErrorToCategory(DWORD code);
+
+// Category key for a Win32 errcode; unmapped codes collapse to category::kUnknown.
+std::string CategoryFromWinError(DWORD code);
+
+}  // namespace x509_cert_store
+
+#endif  // FLUTTER_PLUGIN_X509_CERT_STORE_CATEGORIES_H_

--- a/windows/x509_cert_store_plugin.cpp
+++ b/windows/x509_cert_store_plugin.cpp
@@ -4,6 +4,8 @@
 #include <windows.h>
 #include <wincrypt.h>
 
+#include "x509_cert_store_categories.h"
+
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
@@ -25,11 +27,11 @@ namespace x509_cert_store {
 std::optional<std::string> MapWinErrorToCategory(DWORD code) {
   switch (code) {
     case CRYPT_E_EXISTS:       // 0x80092005 (2148081669)
-      return "alreadyExist";
+      return category::kAlreadyExist;
     case ERROR_CANCELLED:      // 1223
-      return "canceled";
+      return category::kCanceled;
     case ERROR_ACCESS_DENIED:  // 5
-      return "accessDenied";
+      return category::kAccessDenied;
     default:
       return std::nullopt;
   }
@@ -38,7 +40,7 @@ std::optional<std::string> MapWinErrorToCategory(DWORD code) {
 // Choose the category key from a raw Win32 errcode. Always returns a
 // non-empty key - unmapped errors collapse to "unknown".
 std::string CategoryFromWinError(DWORD code) {
-  return MapWinErrorToCategory(code).value_or("unknown");
+  return MapWinErrorToCategory(code).value_or(category::kUnknown);
 }
 
 // Send an error response on the method channel.
@@ -54,7 +56,7 @@ void SendErrorResponse(
     const std::string& error_message,
     DWORD win_error_code = 0) {
   EncodableMap details;
-  if (category == "unknown" && win_error_code != 0) {
+  if (category == category::kUnknown && win_error_code != 0) {
     details[EncodableValue("nativeCode")] =
         EncodableValue(static_cast<int64_t>(win_error_code));
   } else {
@@ -117,7 +119,7 @@ bool AddCertificateToStore(
     std::string& category,
     std::string& errorMessage,
     DWORD& nativeCode) {
-  category = "unknown";
+  category = category::kUnknown;
   nativeCode = 0;
 
   // Guard against empty input before any indexing (certificateData[0] below)
@@ -125,7 +127,7 @@ bool AddCertificateToStore(
   // decodes to an empty vector, which would otherwise be an out-of-bounds
   // read. macOS surfaces this as invalidFormat; match that here.
   if (certificateData.empty()) {
-    category = "invalidFormat";
+    category = category::kInvalidFormat;
     errorMessage = "Certificate data is empty";
     return false;
   }
@@ -141,7 +143,7 @@ bool AddCertificateToStore(
   if (certificateData[0] != 0x30) {
     certificateData = ConvertPemToDer(certificateData);
     if (certificateData.empty()) {
-      category = "invalidFormat";
+      category = category::kInvalidFormat;
       errorMessage = "Failed to convert PEM to DER format";
       CertCloseStore(hStore, 0);
       return false;
@@ -211,7 +213,7 @@ void X509CertStorePlugin::HandleMethodCall(
       const auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
 
       if (!arguments) {
-        SendErrorResponse(result, "unknown", "Missing or invalid arguments");
+        SendErrorResponse(result, category::kUnknown, "Missing or invalid arguments");
         return;
       }
 
@@ -222,14 +224,14 @@ void X509CertStorePlugin::HandleMethodCall(
       if (storeNameIter == arguments->end() ||
           certificateIter == arguments->end() ||
           addTypeIter == arguments->end()) {
-        SendErrorResponse(result, "unknown", "Missing required parameters");
+        SendErrorResponse(result, category::kUnknown, "Missing required parameters");
         return;
       }
 
       if (!std::holds_alternative<std::string>(storeNameIter->second) ||
           !std::holds_alternative<std::vector<uint8_t>>(certificateIter->second) ||
           !std::holds_alternative<int>(addTypeIter->second)) {
-        SendErrorResponse(result, "unknown", "Parameters have incorrect type");
+        SendErrorResponse(result, category::kUnknown, "Parameters have incorrect type");
         return;
       }
 


### PR DESCRIPTION
Closes #9.

The five method-channel category keys (`canceled` / `alreadyExist` / `accessDenied` / `invalidFormat` / `unknown`) were hardcoded as bare string literals in all three layers, with no compile-time check that they agree — a typo in any one silently degrades to `unknown`. This collects them into named constants per language.

## Changes

- **C++:** new `windows/x509_cert_store_categories.h` (`category::k*` constants + `MapWinErrorToCategory` / `CategoryFromWinError` declarations), used throughout `plugin.cpp`. Adds hermetic gtests pinning the Win32-error→key mapping and the constant values **against the literal wire strings** (not the constants — asserting a constant against itself would be tautological).
- **Swift:** new `macos/Classes/CategoryKeys.swift` (`X509Category`), used in `X509CertStorePlugin.swift`.
- **Dart:** `_CategoryKeys` in `x509_cert_store_method_channel.dart`, used in `_parseCategory`.

The wire strings crossing the method channel are unchanged; this is DRY within each language, with a cross-reference comment linking the three files.

## Verification

- **Dart:** `flutter analyze` + `flutter test` (8 pass) + `dart format` — green locally.
- **C++:** built via `flutter build windows --debug`, and the native gtest binary was **run locally** (6 tests pass, including the 3 new `X509CertStoreCategories` tests).
- **Swift:** compile-checked by the `build-macos` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)