### PR TITLE
chore: release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.0.2
+
+### Fixed
+- Windows: an empty certificate (empty base64) no longer triggers an out-of-bounds read; it now fails cleanly with `X509ErrorCode.invalidFormat`, matching macOS behavior.
+- Windows: hardened PEM parsing against malformed input where the `END` marker precedes `BEGIN` (previously surfaced as `unknown`; now `invalidFormat`).
+- macOS: fixed a `CFError` memory leak on the certificate-comparison failure path (`isNewerCertificate`).
+- macOS: a failed certificate deletion during the "add newer" flow on the login keychain now surfaces as an error instead of being silently ignored, consistent with the system keychain.
+- Dart: a non-`true` native result returned without an error is now reported as `X509Failure(X509ErrorCode.unknown)` instead of a false `X509Success`.
+
+### Internal
+- Added a GitHub Actions CI pipeline (analyze, Dart unit tests, Windows/macOS native compile) and wired up the Windows native gtest target.
+- Deduplicated the macOS login/system keychain implementations behind a shared `KeyChainManager` protocol extension.
+- Centralized the method-channel error-category keys into named constants across the C++, Swift, and Dart layers.
+
 ## 2.0.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Linux support coming soon!
 
 ```yaml
 dependencies:
-  x509_cert_store: ^2.0.1
+  x509_cert_store: ^2.0.2
 ```
 
 Or run:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -330,7 +330,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.0.2"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x509_cert_store
 description: "A Flutter plugin for Windows and macOS desktop applications that enables adding X.509 certificates to the local certificate store with trust settings support."
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/kihyun1998/x509_cert_store
 repository: https://github.com/kihyun1998/x509_cert_store
 issue_tracker: https://github.com/kihyun1998/x509_cert_store/issues


### PR DESCRIPTION
Version bump 2.0.1 -> 2.0.2 with CHANGELOG and README updates.

Patch release: all changes since 2.0.1 are bug fixes and internal improvements (issues #7-#12) with no public API additions or breaks.

## Files
- `pubspec.yaml`: `version: 2.0.2`
- `CHANGELOG.md`: new `## 2.0.2` section (Fixed + Internal)
- `README.md`: install constraint `^2.0.2`

## Included since 2.0.1
- **Fixed:** Windows empty-cert OOB guard (#7), Windows PEM parse hardening (#11), macOS CFError leak (#10), macOS add-newer delete-failure consistency (#8), Dart non-true-result handling (#11).
- **Internal:** CI pipeline + native gtest target (#12), macOS keychain dedup (#8), error-category-key centralization (#9).

`flutter pub publish --dry-run` passes (only the expected "uncommitted files" warning, which this commit resolves).

Note: publishing to pub.dev is a separate manual step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)