### PR TITLE
[CI] Run real macOS XCTests (replace stale stub)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           ctest --test-dir plugins/x509_cert_store -C Debug --output-on-failure
 
   build-macos:
-    name: Build macOS (native compile)
+    name: macOS (build + native XCTest)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +55,16 @@ jobs:
       - name: Resolve dependencies
         working-directory: example
         run: flutter pub get
+      # Must build first, or the generated Flutter/ephemeral/*.xcfilelist files
+      # are missing and the Xcode build fails.
       - name: Build macOS example
         working-directory: example
         run: flutter build macos --debug
+      - name: Run native tests
+        working-directory: example
+        run: |
+          xcodebuild test \
+            -workspace macos/Runner.xcworkspace \
+            -scheme Runner \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -2,27 +2,65 @@ import Cocoa
 import FlutterMacOS
 import XCTest
 
-
 @testable import x509_cert_store
 
-// This demonstrates a simple unit test of the Swift portion of this plugin's implementation.
-//
-// See https://developer.apple.com/documentation/xctest for more information about using XCTest.
-
+// Exercises the macOS plugin through its public handle(_:result:) entry point.
+// Every case here is side-effect-free: it either trips an argument guard or
+// fails certificate parsing (SecCertificateCreateWithData) before any keychain
+// access, so it is safe to run in CI. Replaces the default getPlatformVersion
+// template test, which called a method the plugin never implemented.
 class RunnerTests: XCTestCase {
 
-  func testGetPlatformVersion() {
+  private func invoke(_ method: String, arguments: Any?) -> Any? {
     let plugin = X509CertStorePlugin()
-
-    let call = FlutterMethodCall(methodName: "getPlatformVersion", arguments: [])
-
-    let resultExpectation = expectation(description: "result block must be called.")
+    let call = FlutterMethodCall(methodName: method, arguments: arguments)
+    var captured: Any?
+    let done = expectation(description: "result delivered")
     plugin.handle(call) { result in
-      XCTAssertEqual(result as! String,
-                     "macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
-      resultExpectation.fulfill()
+      captured = result
+      done.fulfill()
     }
     waitForExpectations(timeout: 1)
+    return captured
   }
 
+  func testUnknownMethodReturnsNotImplemented() {
+    let result = invoke("noSuchMethod", arguments: nil)
+    XCTAssertTrue(result as AnyObject === FlutterMethodNotImplemented)
+  }
+
+  func testAddCertificateWithMissingArgumentsReturnsUnknownError() {
+    // "certificate" and "addType" are absent: the argument guard rejects the
+    // call before any keychain access.
+    let result = invoke("addCertificate", arguments: ["storeName": "MY"])
+    let error = result as? FlutterError
+    XCTAssertNotNil(error)
+    XCTAssertEqual(error?.code, X509Category.unknown)
+  }
+
+  func testAddCertificateWithInvalidDataReturnsInvalidFormat() {
+    // Well-formed arguments but bytes that are not a DER certificate:
+    // SecCertificateCreateWithData returns nil and the plugin maps this to
+    // invalidFormat. No keychain item is ever added.
+    let garbage = FlutterStandardTypedData(bytes: Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    let result = invoke(
+      "addCertificate",
+      arguments: [
+        "storeName": "MY",
+        "certificate": garbage,
+        "addType": 1,
+      ])
+    let error = result as? FlutterError
+    XCTAssertNotNil(error)
+    XCTAssertEqual(error?.code, X509Category.invalidFormat)
+  }
+
+  func testCategoryConstantsMatchWireContract() {
+    // These keys are the wire contract shared with the Dart and Windows layers.
+    XCTAssertEqual(X509Category.canceled, "canceled")
+    XCTAssertEqual(X509Category.alreadyExist, "alreadyExist")
+    XCTAssertEqual(X509Category.accessDenied, "accessDenied")
+    XCTAssertEqual(X509Category.invalidFormat, "invalidFormat")
+    XCTAssertEqual(X509Category.unknown, "unknown")
+  }
 }


### PR DESCRIPTION
## Summary

The macOS `RunnerTests` was the default template stub (testing a `getPlatformVersion` method the plugin never implements). Replaced with real, side-effect-free tests through the public `handle(_:result:)`:

- unknown method → `FlutterMethodNotImplemented`
- `addCertificate` missing args → `unknown` error (argument guard)
- `addCertificate` invalid bytes → `invalidFormat` (fails `SecCertificateCreateWithData` before any keychain access)
- category constants match the wire contract

The macOS CI job now runs these via `xcodebuild test` (after `flutter build macos`), mirroring the Windows job that runs its gtest suite.

## Verification

Authored on a Windows host (no macOS), so **this PR's `macOS` check is the verification** — the tests are designed to avoid any keychain side effects so they run cleanly on the runner.