### PR TITLE
docs: mark Linux as unsupported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ A Flutter plugin for Windows and macOS desktop applications that enables adding 
 
 | macOS | Windows | Linux |
 |:-----:|:-------:|:-----:|
-|   ✅   |    ✅    |   🔜   |
+|   ✅   |    ✅    |   ❌   |
 
-Linux support coming soon!
+Linux is not supported. The plugin ships only Windows and macOS
+implementations; calling it on Linux throws `MissingPluginException`.
 
 ## Installation
 


### PR DESCRIPTION
The README's Platform Support table showed Linux as "coming soon" (🔜), but the plugin has no Linux implementation:

- no `linux/` directory / native sources
- `pubspec.yaml` declares only `windows` and `macos` plugin platforms
- calling the plugin on Linux throws `MissingPluginException`

This changes the table entry to ❌ and replaces the "coming soon" line with a plain statement that Linux is unsupported, so consumers aren't misled into targeting it.

Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)